### PR TITLE
Add CodeChain's media information and GitHub queries

### DIFF
--- a/rib-bible.md
+++ b/rib-bible.md
@@ -15,10 +15,20 @@ Guidelines when looking for content:
 Media:
 
 - https://medium.com/codechain
+- https://twitter.com/codechain_io
+- https://research.codechain.io
 
 Github queries:
 
 - https://github.com/CodeChain-io/codechain/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/foundry/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/rust-merkle-trie/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/rust-codechain-primitives/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/jsonrpc-filter/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/rlp/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/rust-codechain-db/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/rust-codechain-crypto/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
+- https://github.com/CodeChain-io/vrf-rs/pulls?q=is%3Apr+is%3Amerged+closed%3A%3E2019-12-01+sort%3Acomments-desc
 
 Most active:
 


### PR DESCRIPTION
Last time, @majecty asked to add only [medium](https://medium.com/codechain) and [CodeChain](https://github.com/CodeChain-io/codechain/) projects. In fact, CodeChain has many more projects. In short, we have the [Foundry](https://github.com/CodeChain-io/foundry/) project, a programmable open-source blockchain engine, and independent library projects, such as [the Merkle trie](https://github.com/CodeChain-io/rust-merkle-trie/) and [cryptography library](https://github.com/CodeChain-io/rust-codechain-crypto). They are all actively going on. Furthermore, you can find news about CodeChain on [Twitter]( https://twitter.com/codechain_io), and find out what CodeChain is doing at [research.codechain.io](https://research.codechain.io). So I added CodeChain’s media information and GitHub queries to give an update about these projects.

I work as a core developer at CodeChain. From now on, I’m in charge of next month's update for the next edition. I look forward to your kind cooperation. Thank you. : )