### PR TITLE
add recently open Golem Rust repos

### DIFF
--- a/rib-bible.md
+++ b/rib-bible.md
@@ -85,6 +85,9 @@ GitHub:
 "golemfactory/golem-client",
 "golemfactory/gMorph",
 "golemfactory/hello-gwasm-runner",
+"golemfactory/yagna",
+"golemfactory/ya-client",
+"golemfactory/gwasm-rust-api",
 ]
 
 ## Grin


### PR DESCRIPTION
Add Golemfactory recently opened rust repositories to rib-bible.md, notably our yagna repo where we like to put some of our favourite Rust code :)
Nice The Flourishing Spring RiB update, by the way!