### PR TITLE
rib-newsletter-23: add cosmos-sdk-rs

### DIFF
--- a/draft/rib-newsletter-23.md
+++ b/draft/rib-newsletter-23.md
@@ -54,6 +54,7 @@ Each month we like to shine a light on a notable Rust blockchain project. This m
 
 #### Projects
 
+- [cosmos-sdk-rs: an implementation of the Cosmos SDK in Rust](https://forum.cosmos.network/t/ann-cosmos-sdk-for-rust-v0-1-initial-release/4647)
 
 &nbsp;
 


### PR DESCRIPTION
Adds a Projects link to Cosmos SDK for Rust. Initial 0.1 release was today 🎉 

This PR links to the release announcement.