### PR TITLE
Add job for Fuel Labs

### DIFF
--- a/content/job-board.md
+++ b/content/job-board.md
@@ -53,6 +53,9 @@ Findora | Beijing, China; Menlo Park, CA
 - [Director of Engineering](https://jobs.lever.co/findora/d1981ece-fb53-4b41-96d9-346b1974a7d8)
 - [Senior Systems Engineer](https://jobs.lever.co/findora/e89e2e02-622c-41da-a14d-c12d854a25b5)
 
+Fuel Labs | Remote
+- [Senior Software Engineer [Rust]](https://jobs.lever.co/fuellabs/13b01903-490a-4497-b778-35434f4188cf)
+
 Kraken | Remote
 - [Backend Engineer - Crypto Payments](https://jobs.lever.co/kraken/39031c44-2060-467d-8991-79f23deacbb8)
 - [Backend Engineer - Fiat Payments](https://jobs.lever.co/kraken/bd3d0185-eb56-441e-8ceb-5757711dae8c)

--- a/draft/rib-newsletter-23.md
+++ b/draft/rib-newsletter-23.md
@@ -152,6 +152,9 @@ Company name | Location A, B, Remote
 - [Job 2](https://job.two)
 -->
 
+Fuel Labs | Remote
+- [Senior Software Engineer [Rust]](https://jobs.lever.co/fuellabs/13b01903-490a-4497-b778-35434f4188cf)
+
 Subspace Labs | Remote
 - [Core Protocol Engineer](https://jobs.lever.co/subspacelabs/7f6a654b-60a8-4740-aa19-36b9f7a9e624)
 


### PR DESCRIPTION
Fuel Labs is building a Rust-based optimistic rollup. Add job posting.