### PR TITLE
Added link to StoffelMPC

### DIFF
--- a/draft/rib-newsletter-35.md
+++ b/draft/rib-newsletter-35.md
@@ -46,6 +46,8 @@ Each month we like to shine a light on a notable Rust blockchain project. This m
 
 ## Interesting Things
 
+- [StoffelMPC: A framework for building MPC as a sidechain applications for blockchains](https://write.as/hashcloaks-blog/announcing-stoffelmpc-an-mpc-as-a-sidechain-framework)
+
 #### News
 
 

--- a/draft/rib-newsletter-35.md
+++ b/draft/rib-newsletter-35.md
@@ -46,7 +46,6 @@ Each month we like to shine a light on a notable Rust blockchain project. This m
 
 ## Interesting Things
 
-- [StoffelMPC: A framework for building MPC as a sidechain applications for blockchains](https://write.as/hashcloaks-blog/announcing-stoffelmpc-an-mpc-as-a-sidechain-framework)
 
 #### News
 
@@ -59,6 +58,7 @@ Each month we like to shine a light on a notable Rust blockchain project. This m
 
 #### Projects
 
+- [StoffelMPC: A framework for building MPC as a sidechain applications for blockchains](https://write.as/hashcloaks-blog/announcing-stoffelmpc-an-mpc-as-a-sidechain-framework)
 
 &nbsp;
 


### PR DESCRIPTION
At HashCloak, we are building StoffelMPC, a framework for building MPC as a sidechain applications.
