### PR TITLE
fix: broken links

### DIFF
--- a/content/newsletters/RiB-Newsletter-#11-Apr-2020.md
+++ b/content/newsletters/RiB-Newsletter-#11-Apr-2020.md
@@ -164,7 +164,7 @@ See the announcments of [`k256` and `p256`][rca1] and [`signature` and
 - Project: [rust-vyper](https://github.com/ethereum/rust-vyper). An implementation of the [Vyper](https://github.com/vyperlang/vyper) smart-contract language.
 - Report: [Analyzing Developers in Cryptocurrency Projects](https://blog.coincodecap.com/analyzing-developers-in-cryptocurrency-projects/)
 - Blog: [When Tailwinds Vanish](https://luttig.substack.com/p/when-tailwinds-vanish)
-- Blog: [Gitcoin Grants Round 5 Retrospective](https://vitalik.ca/general/2020/04/30/round5.html). Vitalik Buterin analyzes efforts to crowd-fund Ethereum projects. Not Rust-related, but interesting analysis about sustainable community development.
+- Blog: [Gitcoin Grants Round 5 Retrospective](https://vitalik.eth.limo/general/2020/04/30/round5.html). Vitalik Buterin analyzes efforts to crowd-fund Ethereum projects. Not Rust-related, but interesting analysis about sustainable community development.
 - Blog: [Crypto Fund II](https://a16z.com/2020/04/30/crypto-fund-ii/). Andreeessen Horowitz announced $500-million in available crypto-related funding. Not Rust.
 
 &nbsp;

--- a/content/newsletters/rib-newsletter-19-dec-2020.md
+++ b/content/newsletters/rib-newsletter-19-dec-2020.md
@@ -182,7 +182,7 @@ Currently that includes Substrate, Solana, [ewasm], and [Sawtooth].
 
 - [A Brief Breakdown of Monero’s Ongoing Network Attacks](https://sethsimmons.me/posts/moneros-ongoing-network-attack/)
 - [Understanding Peer-to-Peer Git Forges with Radicle](http://blog.vmsplice.net/2020/12/understanding-peer-to-peer-git-forges.html)
-- [An Incomplete Guide to Rollups](https://vitalik.ca/general/2021/01/05/rollup.html)
+- [An Incomplete Guide to Rollups](https://vitalik.eth.limo/general/2021/01/05/rollup.html)
 - [Notes on cross-compiling Rust](https://john-millikin.com/notes-on-cross-compiling-rust)
 
 #### Papers 

--- a/content/newsletters/rib-newsletter-20-jan-2021.md
+++ b/content/newsletters/rib-newsletter-20-jan-2021.md
@@ -123,7 +123,7 @@ It is described further in [a post on the Ethereum research forum][mevpost].
 - [Candid: A Common Language for Application Interfaces on the Internet Computer](https://medium.com/dfinity/candid-a-tool-for-interoperable-programming-languages-on-the-internet-computer-27e7085cd97f).
   Source code: [Candid](https://github.com/dfinity/candid).
 - [First impressions of programming on DFINITY](https://brson.github.io/2021/01/30/dfinity-impressions)
-- [An approximate introduction to how zk-SNARKs are possible](https://vitalik.ca/general/2021/01/26/snarks.html).
+- [An approximate introduction to how zk-SNARKs are possible](https://vitalik.eth.limo/general/2021/01/26/snarks.html).
   A typically good post from Vitalik that helps illuminate a difficult subject
 
 #### Papers

--- a/content/newsletters/rib-newsletter-22.md
+++ b/content/newsletters/rib-newsletter-22.md
@@ -100,7 +100,7 @@ independent of specific blockchains.
 
 #### Blog Posts
 
-- [The Most Important Scarce Resource is Legitimacy](https://vitalik.ca/general/2021/03/23/legitimacy.html)
+- [The Most Important Scarce Resource is Legitimacy](https://vitalik.eth.limo/general/2021/03/23/legitimacy.html)
 - [Further adventures with Substrate and Ink](https://brson.github.io/2021/03/09/further-adventures-with-substrate-and-ink)
 
 #### Papers

--- a/content/newsletters/rib-newsletter-33.md
+++ b/content/newsletters/rib-newsletter-33.md
@@ -70,7 +70,7 @@ two parties, performed over Tor, that results in exchanging ownership of two dif
 
 - [Rust Survey 2021 Results](https://blog.rust-lang.org/2022/02/15/Rust-Survey-2021.html)
 - [What Are Cross-Chain Smart Contracts?](https://blog.chain.link/cross-chain-smart-contracts/)
-- [Encapsulated vs systemic complexity in protocol design](https://vitalik.ca/general/2022/02/28/complexity.html)
+- [Encapsulated vs systemic complexity in protocol design](https://vitalik.eth.limo/general/2022/02/28/complexity.html)
 
 #### Papers
 

--- a/content/newsletters/rib-newsletter-39.md
+++ b/content/newsletters/rib-newsletter-39.md
@@ -84,7 +84,7 @@ and is wasm-compatible.
 - Tutorial: [BrainSTARK](https://aszepieniec.github.io/stark-brainfuck/)
 - [Decentralized Application (dApp) Blockchain Tutorials (NEAR,Solana,Substrate)](https://github.com/elicorrales/blockchain-tutorials)
 - [Sin7Y Tech Review(29): Design Principles of Private Transactions in Aleo & Zcash](https://hackmd.io/@sin7y/rkxFXLkgs)
-- [The different types of ZK-EVMs](https://vitalik.ca/general/2022/08/04/zkevm.html)
+- [The different types of ZK-EVMs](https://vitalik.eth.limo/general/2022/08/04/zkevm.html)
 - [How consensus and data availability impact decentralized scalability of blockchains](https://kabat.substack.com/p/how-consensus-and-data-availability)
 - [On-chain trusted setup ceremony](https://a16zcrypto.com/on-chain-trusted-setup-ceremony/)
 


### PR DESCRIPTION
Updated outdated or broken links to their current versions.

This pull request addresses broken links in the following files:
- `rib-newsletter-22.md`
- `rib-newsletter-33.md`
- `rib-newsletter-39.md`
- `rib-newsletter-20-jan-2021.md`
- `rib-newsletter-19-dec-2020.md`
- `RiB-Newsletter-#11-Apr-2020.md`